### PR TITLE
fix nil pointer dereference

### DIFF
--- a/genericOidc_test.go
+++ b/genericOidc_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func TestGenericOIDC_User(t *testing.T) {
 				},
 			},
 			want:         nil,
-			wantErrAtNew: errors.New("Get \"https://wrongIssuer/.well-known/openid-configuration\": dial tcp: lookup wrongIssuer on 127.0.0.53:53: server misbehaving"),
+			wantErrAtNew: errors.New("Get \"https://wrongIssuer/.well-known/openid-configuration\": dial tcp: lookup wrongIssuer"),
 		},
 		{
 			name: "Wrong audience",
@@ -223,7 +224,7 @@ func TestGenericOIDC_User(t *testing.T) {
 
 			o, err := NewGenericOIDC(ic, Timeout(1*time.Second))
 			if err != nil {
-				if tt.wantErrAtNew == nil || tt.wantErrAtNew.Error() != err.Error() {
+				if tt.wantErrAtNew == nil || !strings.HasPrefix(err.Error(), tt.wantErrAtNew.Error()) {
 					t.Fatalf("NewGenericOIDC() error = %v, wantErr %v", err, tt.wantErrAtNew)
 				}
 

--- a/issuercache.go
+++ b/issuercache.go
@@ -134,6 +134,12 @@ func (i *MultiIssuerCache) User(rq *http.Request) (*User, error) {
 			}
 		})
 		if err != nil {
+			// set a new sync.Once because the current one is wasted now and will never ever
+			// initialize the issuer. Later invocations will fall through and produce
+			// a nil pointer dereference
+			iss.ugOnce = sync.Once{}
+			i.updateCachedIssuer(iss)
+
 			// lazy initialization failed
 			return nil, err
 		}

--- a/issuercache_test.go
+++ b/issuercache_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -419,4 +420,49 @@ func TestMultiIssuerCache_syncCache(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_IssuerOnceReset(t *testing.T) {
+	tc := DefaultTokenCfg()
+	tc.ExpiresAt = time.Now().Add(1 * time.Hour)
+
+	srv, token, err := GenerateTokenAndKeyServer(tc, MustCreateTokenAndKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	invocations := 0
+	ir, err := NewMultiIssuerCache(slog.New(slog.NewJSONHandler(os.Stdout, nil)), func() ([]*IssuerConfig, error) {
+		return []*IssuerConfig{
+			{
+				Tenant:   "Tn",
+				Issuer:   srv.URL,
+				ClientID: tc.Audience[0],
+			},
+		}, nil
+	}, func(ic *IssuerConfig) (UserGetter, error) {
+		ug, err := NewGenericOIDC(ic, GenericUserExtractor(DefaultGenericUserExtractor))
+		if invocations == 0 {
+			invocations++
+			return nil, fmt.Errorf("first invocation should fail")
+		}
+		return ug, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ir.User(&http.Request{
+		Header: createHeader(AuthzHeaderKey, "bearer "+token),
+	})
+	assert.Nil(t, got, "result should be nil")
+	assert.Error(t, err, "an error is required on first invocation")
+	assert.Equal(t, "first invocation should fail", err.Error(), "wrong error type")
+
+	got, err = ir.User(&http.Request{
+		Header: createHeader(AuthzHeaderKey, "bearer "+token),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, tc.Email, got.EMail, "email should be equal")
 }

--- a/issuercache_test.go
+++ b/issuercache_test.go
@@ -457,12 +457,12 @@ func Test_IssuerOnceReset(t *testing.T) {
 		Header: createHeader(AuthzHeaderKey, "bearer "+token),
 	})
 	assert.Nil(t, got, "result should be nil")
-	assert.Error(t, err, "an error is required on first invocation")
+	require.Error(t, err, "an error is required on first invocation")
 	assert.Equal(t, "first invocation should fail", err.Error(), "wrong error type")
 
 	got, err = ir.User(&http.Request{
 		Header: createHeader(AuthzHeaderKey, "bearer "+token),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, tc.Email, got.EMail, "email should be equal")
 }


### PR DESCRIPTION
The current Code produces a nil pointer dereference when the code block in the `sync.Once` fails and in a later iteration the same code is tried again.

In such a case the once will not be invoked again, the `error` is empty and in the line

~~~go
iss.userGetter.User(rq)
~~~

the field `userGetter` is nil and so it crashes. As the `sync.Once` is never resetted, the code cannot repair the situation.