### PR TITLE
fix(cache): retry period

### DIFF
--- a/issuercache_test.go
+++ b/issuercache_test.go
@@ -296,7 +296,7 @@ func TestMultiIssuerCache_retryFailing(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	assert.Equal(t, 4, calls)
-	assert.Len(t, ic.cache, 0)
+	assert.Empty(t, ic.cache)
 }
 
 func TestMultiIssuerCache_retrySecondReload(t *testing.T) {


### PR DESCRIPTION
Retries getting the issuer list on failure. Otherwise the cache stays empty for the default reload time of 30 minutes.

Should fix https://github.com/metal-stack/metal-api/issues/259 if I didn't mix up something. But even in that case this error could still happen.