### PR TITLE
feat: add support for groups when roles are missing

### DIFF
--- a/genericOidc.go
+++ b/genericOidc.go
@@ -20,7 +20,8 @@ type GenericOIDCClaims struct {
 	Name              string   `json:"name"`
 	PreferredUsername string   `json:"preferred_username"`
 	EMail             string   `json:"email"`
-	Roles             []string `json:"roles"`
+	Roles             []string `json:"roles,omitempty"`
+	Groups            []string `json:"groups,omitempty"`
 }
 
 func (g *GenericOIDCClaims) Username() string {
@@ -28,6 +29,14 @@ func (g *GenericOIDCClaims) Username() string {
 		return g.PreferredUsername
 	}
 	return g.Name
+}
+
+// Returns Roles and falls back to Groups if not set.
+func (g *GenericOIDCClaims) Memberships() []string {
+	if len(g.Roles) != 0 {
+		return g.Roles
+	}
+	return g.Groups
 }
 
 // GenericOIDC is Token Validator and UserGetter for Tokens issued by generic OIDC-Providers.
@@ -154,7 +163,7 @@ func DefaultGenericUserExtractor(ic *IssuerConfig, claims *GenericOIDCClaims) (*
 		return nil, errors.New("claims is nil")
 	}
 	var grps []ResourceAccess
-	for _, g := range claims.Roles {
+	for _, g := range claims.Memberships() {
 		grps = append(grps, ResourceAccess(g))
 	}
 


### PR DESCRIPTION
## Description

In practice not all OIDC providers expose roles. Some expose groups instead. We still prefer roles when possible, but fall back to groups. Alternatively a new type of user extractor would be required to be introduced, effectively requiring to add a new config field for iam tenant configs and still adding the same config field to the generic claims.

This should be not break any clients.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
